### PR TITLE
Fix jest complaining about low test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && jest"
     }
   },
   "lint-staged": {
@@ -50,8 +50,7 @@
       "npm run fmt"
     ],
     "*.{ts,js}": [
-      "npm run fmt",
-      "jest --bail --findRelatedTests"
+      "npm run fmt"
     ]
   }
 }


### PR DESCRIPTION
Jest used to run only on changed tests and therefore not capture the
entire testsuite. It reported a wrong coverage.

Now we run jest on all tests before commits and will get the real test
coverage in return for slightly longer test runs.