### PR TITLE
CI tests run only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ name: CI
       - feature/**
       - fix/**
       - docs/**
-  pull_request:
-    branches:
       - master
       - dev
 jobs:


### PR DESCRIPTION
Previously the ci steps would run after pushing and before merging,
but because they test exactly the same thing we can safely remove it.

Now it will only test on push and you have to update the branch
before merging.