### PR TITLE
Add defaults to jsdoc rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,8 @@
 const jsdocRules = {
   "jsdoc/require-param-type": "off",
   "jsdoc/require-returns-type": "off",
+  "jsdoc/no-types": "error",
+  "jsdoc/require-jsdoc": "error",
 }
 
 module.exports = {


### PR DESCRIPTION
- no-types: We are using typescript and that must be the single source
 	of truth.
- require-jsdoc: We want a high documentation coverage, so we require
	docstrings for all functions.