### PR TITLE
Fix the lint-staged pattern for .ts and js.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         run: npm install
       - name: lint and format
         run: npm run fmt
+      - name: Hadolint
+        run: |
+          docker run --rm -i hadolint/hadolint < ./service/Dockerfile
+          docker run --rm -i hadolint/hadolint < ./service/rsyslog/Dockerfile
   tests:
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "description": "Swapchain is an application for performing ACCS (atomic cross chain swaps) via HTLCs (hash-time-locked contracts).",
   "main": "index.js",
   "scripts": {
-    "fmt": "eslint --fix --ext .ts ./ && prettier --write ./**/*.{js,ts,json} --loglevel warn",
-    "test": "jest",
     "build": "./node_modules/.bin/tsc",
-    "docs:build": "typedoc && cd docs && npm run && npm run build",
-    "docs:show": "typedoc && cd docs && npm run start"
+    "docker:up": "docker-compose build && docker-compose up",
+    "docs:build": "./node_modules/.bin/typedoc && cd docs && npm run && npm run build",
+    "docs:show": "./node_modules/.bin/typedoc && cd docs && npm run start",
+    "eslint": "./node_modules/.bin/eslint --fix --ext .ts ./",
+    "fmt": "npm run lint && npm run prettier",
+    "lint:docker": "docker run --rm -i hadolint/hadolint < ./src/srv/Dockerfile",
+    "lint": "npm run lint:docker && npm run eslint",
+    "prettier": "./node_modules/.bin/prettier --write ./**/*.{js,ts,json} --loglevel warn",
+    "test": "./node_modules/.bin/jest"
   },
   "repository": {
     "type": "git",
@@ -25,6 +30,9 @@
     "url": "https://github.com/chronark/swapchain/issues"
   },
   "homepage": "https://github.com/chronark/swapchain#readme",
+  "dependencies": {
+    "express": "^4.17.1"
+  },
   "devDependencies": {
     "@types/express": "^4.17.6",
     "@types/jest": "^25.2.1",
@@ -36,7 +44,6 @@
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-jsdoc": "^24.0.0",
     "eslint-plugin-prettier": "^3.1.3",
-    "express": "^4.17.1",
     "husky": "^4.2.5",
     "jest": "^25.5.1",
     "lint-staged": "^10.2.0",
@@ -57,7 +64,7 @@
     "**/*.{json,md, yml}": [
       "npm run fmt"
     ],
-    "*.{ts,js}": [
+    "**/*.{ts,js}": [
       "npm run fmt"
     ]
   }


### PR DESCRIPTION
The file glob was not configured correctly and only gathering files in
the root directory.