### PR TITLE
[doc] Remove codacy from readme badges

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -15,12 +15,6 @@
             src="https://github.com/chronark/swapchain/workflows/CI/badge.svg?branch=master">
         </img>
     </a>
-    <a 
-        href="https://www.codacy.com/manual/chronark/swapchain?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=chronark/swapchain&amp;utm_campaign=Badge_Grade">
-        <img 
-            src="https://api.codacy.com/project/badge/Grade/e4c3c0c666f544f6b09d09cf5db21cc6"/>
-        </img>
-    </a>
 </div>
 
 > Swapchain is an application for performing ACCS (atomic cross chain swaps) via HTLCs (hash-time-locked contracts).


### PR DESCRIPTION
There were some issues with integrating codacy
- couldn't set up the post-commit hook
- it detected my account twice and threw errors