### PR TITLE
Fix duplicate package names

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swapchain",
+  "name": "swapchain-documentation",
   "version": "0.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Documentation package name was the same as the main package name.